### PR TITLE
Remove value types: Struct -> Class

### DIFF
--- a/BattleBitAPI/Common/Arguments/OnPlayerKillArguments.cs
+++ b/BattleBitAPI/Common/Arguments/OnPlayerKillArguments.cs
@@ -2,7 +2,7 @@
 
 namespace BattleBitAPI.Common
 {
-    public struct OnPlayerKillArguments<TPlayer> where TPlayer : Player
+    public class OnPlayerKillArguments<TPlayer> where TPlayer : Player
     {
         public TPlayer Killer;
         public Vector3 KillerPosition;

--- a/BattleBitAPI/Common/Data/PlayerLoadout.cs
+++ b/BattleBitAPI/Common/Data/PlayerLoadout.cs
@@ -1,6 +1,6 @@
 ﻿namespace BattleBitAPI.Common
 {
-    public struct PlayerLoadout
+    public class PlayerLoadout
     {
         public WeaponItem PrimaryWeapon;
         public WeaponItem SecondaryWeapon;

--- a/BattleBitAPI/Common/Data/PlayerSpawnRequest.cs
+++ b/BattleBitAPI/Common/Data/PlayerSpawnRequest.cs
@@ -2,7 +2,7 @@
 
 namespace BattleBitAPI.Common
 {
-    public struct PlayerSpawnRequest
+    public class PlayerSpawnRequest
     {
         public PlayerSpawningPosition RequestedPoint;
         public PlayerLoadout Loadout;

--- a/BattleBitAPI/Common/Data/PlayerWearings.cs
+++ b/BattleBitAPI/Common/Data/PlayerWearings.cs
@@ -1,6 +1,6 @@
 ﻿namespace BattleBitAPI.Common
 {
-    public struct PlayerWearings
+    public class PlayerWearings
     {
         public string Head;
         public string Chest;


### PR DESCRIPTION
Unless there's a very good reason why we should have these as value types, these should be reference types.

Reference types have more features and makes it easier to use dynamic .NET (eg reflection) in the API.