### PR TITLE
TGameServer in OnGameServerX & copy paste fix

### DIFF
--- a/BattleBitAPI/Common/Data/PlayerLoadout.cs
+++ b/BattleBitAPI/Common/Data/PlayerLoadout.cs
@@ -282,7 +282,7 @@
                 case AttachmentType.Barrel:
                     return this.Barrel == attachment;
                 case AttachmentType.UnderRail:
-                    return this.Barrel == attachment;
+                    return this.UnderRail == attachment;
                 case AttachmentType.SideRail:
                     return this.SideRail == attachment;
                 case AttachmentType.Bolt:

--- a/BattleBitAPI/Common/Data/PlayerLoadout.cs
+++ b/BattleBitAPI/Common/Data/PlayerLoadout.cs
@@ -307,7 +307,7 @@
                     this.Barrel = attachment;
                     break;
                 case AttachmentType.UnderRail:
-                    this.Barrel = attachment;
+                    this.UnderRail = attachment;
                     break;
                 case AttachmentType.SideRail:
                     this.SideRail = attachment;

--- a/BattleBitAPI/Server/ServerListener.cs
+++ b/BattleBitAPI/Server/ServerListener.cs
@@ -39,7 +39,7 @@ namespace BattleBitAPI.Server
         /// <remarks>
         /// GameServer: Game server that is connecting.<br/>
         /// </remarks>
-        public Func<GameServer<TPlayer>, Task> OnGameServerConnected { get; set; }
+        public Func<TGameServer, Task> OnGameServerConnected { get; set; }
 
         /// <summary>
         /// Fired when a game server reconnects. (When game server connects while a socket is already open)
@@ -48,7 +48,7 @@ namespace BattleBitAPI.Server
         /// <remarks>
         /// GameServer: Game server that is reconnecting.<br/>
         /// </remarks>
-        public Func<GameServer<TPlayer>, Task> OnGameServerReconnected { get; set; }
+        public Func<TGameServer, Task> OnGameServerReconnected { get; set; }
 
         /// <summary>
         /// Fired when a game server disconnects. Check (GameServer.TerminationReason) to see the reason.
@@ -57,7 +57,7 @@ namespace BattleBitAPI.Server
         /// <remarks>
         /// GameServer: Game server that disconnected.<br/>
         /// </remarks>
-        public Func<GameServer<TPlayer>, Task> OnGameServerDisconnected { get; set; }
+        public Func<TGameServer, Task> OnGameServerDisconnected { get; set; }
 
         // --- Private --- 
         private TcpListener mSocket;


### PR DESCRIPTION
This change allows for API user to update their custom properties inside OnServer callbacks.
```c#
class Program
{
    static void Main(string[] args)
    {
        var listener = new ServerListener<MyPlayer, MyGameServer>();
        listener.Start(29294);
        listener.OnGameServerConnected += OnGameServerConnected;
        listener.OnGameServerReconnected += OnGameServerReconnected;
        Thread.Sleep(-1);
    }

    private static async Task OnGameServerConnected(MyGameServer server)
    {
        server.SomeValueOrService = 1337;
    }

    private static async Task OnGameServerReconnected(MyGameServer server)
    {
        server.ReconnectedToCommunityApiCount++;

        if (server.ReconnectedToCommunityApiCount > 10)
        {
            ReportIssue($"Server {server} has trouble keeping connection with the community API. Check ASAP");
        }
    }
}

class MyGameServer : GameServer<MyPlayer> {

    public int SomeValueOrService= -1;
    public int ReconnectedToCommunityApiCount = 0;

    public override async Task OnTick()
    {
        tick++;
        if (tick % 100 == 0)
        {
            Console.WriteLine(SomeValueOrService);
        }
    }
}
```

I also wish there were `OnGameServerInstanceCreated` that get's called right after API creates instance of TGameServer to inject my properties. Because if you do it `OnGameServerConnected`, the server can already get `OnTick` message and properties will still be uninitialized; 
![image](https://github.com/MrOkiDoki/BattleBit-Community-Server-API/assets/20854431/fc674703-7eb1-4060-afab-939c166fa9f6)
