### PR TITLE
Adds server IP and port to OnCreatingGameServerInstance

### DIFF
--- a/BattleBitAPI/Server/ServerListener.cs
+++ b/BattleBitAPI/Server/ServerListener.cs
@@ -81,7 +81,7 @@ namespace BattleBitAPI.Server
         /// <remarks>
         /// GameServer: Game server that has been just created.<br/>
         /// </remarks>
-        public Func<TGameServer> OnCreatingGameServerInstance { get; set; }
+        public Func<IPAddress, int, TGameServer> OnCreatingGameServerInstance { get; set; }
 
         /// <summary>
         /// Fired when a new instance of player instance created.
@@ -382,7 +382,7 @@ namespace BattleBitAPI.Server
                         }
 
                         var hash = ((ulong)gamePort << 32) | (ulong)ip.ToUInt();
-                        server = this.mInstanceDatabase.GetServerInstance(hash, out resources, this.OnCreatingGameServerInstance);
+                        server = this.mInstanceDatabase.GetServerInstance(hash, ip, gamePort, out resources, this.OnCreatingGameServerInstance);
                         resources.Set(
                             this.mExecutePackage,
                             this.mGetPlayerInternals,
@@ -1281,7 +1281,7 @@ namespace BattleBitAPI.Server
                 this.mPlayerInstances = new Dictionary<ulong, (TPlayer, Player<TPlayer>.Internal)>(1024 * 16);
             }
 
-            public TGameServer GetServerInstance(ulong hash, out GameServer<TPlayer>.Internal @internal, Func<TGameServer> createFunc)
+            public TGameServer GetServerInstance(ulong hash, IPAddress serverIp, int serverPort, out GameServer<TPlayer>.Internal @internal, Func<IPAddress, int, TGameServer> createFunc)
             {
                 lock (mGameServerInstances)
                 {
@@ -1295,7 +1295,7 @@ namespace BattleBitAPI.Server
                     GameServer<TPlayer> server;
 
                     if (createFunc != null)
-                        server = createFunc();
+                        server = createFunc(serverIp, serverPort);
                     else
                         server = Activator.CreateInstance<GameServer<TPlayer>>();
 


### PR DESCRIPTION
Reason: https://discord.com/channels/1139105158769426453/1139105160086442006/1142039873461682256

next to ip and port, all the other fields that are already available could also be added.
the requirement for ip and port is specific to my case but there may be other people who have different cases that require other data to be available for creating the game server instance.