### PR TITLE
Add German translation and fix minor issues

### DIFF
--- a/BattleBitAPI/Server/GameServer.cs
+++ b/BattleBitAPI/Server/GameServer.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Net;
+﻿using System.Net;
 using System.Net.Sockets;
 using System.Numerics;
 using System.Text;

--- a/BattleBitAPI/Server/ServerListener.cs
+++ b/BattleBitAPI/Server/ServerListener.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net;
 using System.Net.Sockets;
 using System.Numerics;
-using System.Runtime.CompilerServices;
 using BattleBitAPI.Common;
 using BattleBitAPI.Common.Extentions;
 using BattleBitAPI.Networking;
@@ -190,12 +189,12 @@ namespace BattleBitAPI.Server
                                 throw new Exception("Incoming package wasn't hail.");
                         }
 
-                        //Read the server name
+                        //Read the server token
                         string token;
                         {
                             readStream.Reset();
                             if (!await networkStream.TryRead(readStream, 2, source.Token))
-                                throw new Exception("Unable to read the Token Size");
+                                throw new Exception("Unable to read the token Size");
 
                             int stringSize = readStream.ReadUInt16();
                             if (stringSize > Const.MaxTokenSize)
@@ -339,7 +338,7 @@ namespace BattleBitAPI.Server
                                 throw new Exception("Unable to read the Loading Screen Text Size");
 
                             int stringSize = readStream.ReadUInt16();
-                            if (stringSize < Const.MinLoadingScreenTextLength || stringSize > Const.MaxLoadingScreenTextLength)
+                            if (stringSize > Const.MaxLoadingScreenTextLength)
                                 throw new Exception("Invalid server Loading Screen Text Size");
 
                             if (stringSize > 0)
@@ -364,7 +363,7 @@ namespace BattleBitAPI.Server
                                 throw new Exception("Unable to read the Server Rules Text Size");
 
                             int stringSize = readStream.ReadUInt16();
-                            if (stringSize < Const.MinServerRulesTextLength || stringSize > Const.MaxServerRulesTextLength)
+                            if (stringSize > Const.MaxServerRulesTextLength)
                                 throw new Exception("Invalid server Server Rules Text Size");
 
                             if (stringSize > 0)
@@ -546,7 +545,7 @@ namespace BattleBitAPI.Server
                             {
                                 readStream.Reset();
                                 if (!await networkStream.TryRead(readStream, 4, source.Token))
-                                    throw new Exception("Unable to read the LoadoutSize");
+                                    throw new Exception("Unable to read the Loadout + Wearings size");
                                 int loadoutSize = (int)readStream.ReadUInt32();
 
                                 readStream.Reset();

--- a/BattleBitAPI/Server/ServerListener.cs
+++ b/BattleBitAPI/Server/ServerListener.cs
@@ -338,7 +338,7 @@ namespace BattleBitAPI.Server
                                 throw new Exception("Unable to read the Loading Screen Text Size");
 
                             int stringSize = readStream.ReadUInt16();
-                            if (stringSize > Const.MaxLoadingScreenTextLength)
+                            if (stringSize < Const.MinLoadingScreenTextLength || stringSize > Const.MaxLoadingScreenTextLength)
                                 throw new Exception("Invalid server Loading Screen Text Size");
 
                             if (stringSize > 0)
@@ -363,7 +363,7 @@ namespace BattleBitAPI.Server
                                 throw new Exception("Unable to read the Server Rules Text Size");
 
                             int stringSize = readStream.ReadUInt16();
-                            if (stringSize > Const.MaxServerRulesTextLength)
+                            if (stringSize < Const.MinServerRulesTextLength || stringSize > Const.MaxServerRulesTextLength)
                                 throw new Exception("Invalid server Server Rules Text Size");
 
                             if (stringSize > 0)

--- a/README-de.md
+++ b/README-de.md
@@ -1,0 +1,45 @@
+# BattleBit Remastered Community Server API
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Language English | [中文](/README-zhCN.md) | [한국어](/README-koKR.md) | [German](/README-de.md)
+
+Dieses Repository bietet eine API, die verwendet werden kann, um Ereignisse auf deinen Community-Servern zu verwalten und zu manipulieren.
+
+## Erste Schritte
+
+### Voraussetzungen
+
+- Eigener Community-Server innerhalb von BattleBit Remastered mit **deaktiviertem** Fortschritt und Zugriff auf dessen Startoptionen.
+- Die Fähigkeit, C#-Code [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) zu schreiben und zu kompilieren.
+- (nur Produktivbetrieb) Ein Server, um diese API zu hosten.
+
+### Bearbeiten
+
+Dokumentation und Beispiele findest du im [Wiki](https://github.com/MrOkiDoki/BattleBit-Community-Server-API/wiki).
+
+Die Art und Weise, diese API zu verwenden, besteht darin, eine Instanz von `ServerListener` zu erstellen (und zu starten), an die du die Typen deiner eigenen Unterklassen von `Player` & `GameServer` übergibst. In diesen Unterklassen kannst du deine eigenen Überschreibungen für die bereits vorhandenen virtuellen Methoden in `Player` und `GameServer` erstellen. Du kannst auch eigene Methoden sowie Felder/Eigenschaften hinzufügen.
+
+Der einfachste Weg, mit all dem zu beginnen, besteht darin, Program.cs zu verwenden und deine Überschreibungen usw. in MyPlayer & MyGameServer hinzuzufügen.
+
+### Kompilieren
+
+Dieses Projekt kann entweder mit dem Befehl [`dotnet build`](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build) auf der Kommandozeile kompiliert werden oder durch Verwendung der Ausführungs- / Kompilierungsoptionen in deiner bevorzugten Entwicklungsumgebung (IDE).
+
+Alternativ kannst du Docker verwenden, um es auszuführen. Ein einfacher Weg dazu ist, `docker compose up` auszuführen.
+
+### Verbindung zu dem/den Spielserver/n
+
+Nachdem du dieses Projekt geschrieben und kompiliert hast, musst du es irgendwo hosten. Dies kann auf demselben Server erfolgen, auf dem die Spielserver laufen, oder an einem völlig anderen Ort. Wir empfehlen, um Latenz zu den Spielservern minimal zu halten, und eine reibungslose und schnellere Kommunikation zu gewährleisten, den API Server auf dem selben Host wie den Spielserver zu betreiben. Derselbe `ServerListener` kann gleichzeitig für mehrere Spielserver verwendet werden. Du kannst den API-Server (Adresse & Port) in den Startoptionen des Spielservers angeben.
+
+#### Startargumente für Spielserver
+
+Der Spielserver verbindet sich mit der API mit dem Startargument `"-apiendpoint=<IP>:<port>"`, wobei `<port>` der Port ist, auf dem der Listener lauscht, und `<IP>` die IP des API-Servers ist.
+
+Wenn in deiner Server-API eine Überprüfung des `API-Token` erforderlich ist, musst du `"-apiToken=<ApiToken>"` zu den Startparametern des Spielservers hinzufügen. Sollte `<ApiToken>` mit dem in der Server-API definierten `API-Token` übereinstimmen, können Spielserver mit der Server-API kommunizieren.
+
+Wenn der Spielserver läuft, kannst du das `API-Token` des Spielservers auch direkt über die Eingabe von `setapitoken <neues Token>` in der Befehlszeile ändern.
+
+#### Anpassen des API-Ports
+
+Das Projekt ist derzeit so konfiguriert, dass die API auf Port `29294` hört. Wenn du dies ändern möchtest, stelle sicher, dass du es im Code änderst (bei deinem `listener.start(port)`). Port `29294` ist auch in Docker freigegeben und in Docker Compose an denselben Port auf dem Host gebunden. Das bedeutet, wenn du Docker verwendest, musst du den Port auch in dem `Dockerfile` und in `docker-compose.yml` (bei Verwendung von Compose) ändern. Siehe [EXPOSE in the Dockerfile reference](https://docs.docker.com/engine/reference/builder/#expose) und [Networking in Compose](https://docs.docker.com/compose/networking/).

--- a/README-koKR.md
+++ b/README-koKR.md
@@ -2,7 +2,7 @@
 
  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Language [English](/README.md) | [中文](/README-zhCN.md) | 한국어
+Language [English](/README.md) | [中文](/README-zhCN.md) | 한국어 | [German](/README-de.md)
  
 이 레포지토리는 BattleBit Remastered 커뮤니티 서버에서 이벤트를 처리하고 조작하는 데 사용할 수 있는 API를 제공합니다.
 

--- a/README-zhCN.md
+++ b/README-zhCN.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Language [English](/README.md) | 中文 | [한국어](/README-koKR.md)
+Language [English](/README.md) | 中文 | [한국어](/README-koKR.md) | [German](/README-de.md)
  
 BBR（像素战地）的服务端 API 在部署后可以提供`社区服`所需要的游戏服务端事件处理以及事件控制。
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Language English | [中文](/README-zhCN.md) | [한국어](/README-koKR.md)
+Language English | [中文](/README-zhCN.md) | [한국어](/README-koKR.md) | [German](/README-de.md)
 
 This repository provides an API that can be used to handle events on your community server(s) and manipulate them.
 


### PR DESCRIPTION
- Adds German translation of README
- Adds link to german README to other READMEs
- Remove unused imports
- Correct doc string on stream reading segment that reads new token, not server name
- Add additional info on Exception that fails on not being able to load the size of both data sets. (They are read consecutively, without a seperate check for WearingsSize) 